### PR TITLE
implement range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- In config, the channel range field is now used by the daemon.
+
+### Changed
+- In config, channel range fields are now floats, not strings.
+
 ## [2022.11.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - In config, the channel range field is now used by the daemon.
 
 ### Changed
-- In config, channel range fields are now floats, not strings.
+- In config, channel range fields is now a list of floats (`[min, max]`).
 
 ## [2022.11.0]
 

--- a/example-yaq-configs/ni-daqmx-tmux/wright-fs.toml
+++ b/example-yaq-configs/ni-daqmx-tmux/wright-fs.toml
@@ -19,7 +19,7 @@ baseline_start = 800
 baseline_stop = 830
 baseline_presample = 0
 baseline_method = "average"
-range = "10.0 (320.0)"
+range = [-10.0, 10.0]
 
 [daq.channels.ai1]
 enabled = false
@@ -34,7 +34,7 @@ baseline_start = 732
 baseline_stop = 733
 baseline_presample = 0
 baseline_method = "average"
-range = "10.0 (320.0)"
+range = [-10.0, 10.0]
 
 [daq.channels.ai2]
 enabled = false
@@ -49,7 +49,7 @@ baseline_start = 830
 baseline_stop = 859
 baseline_presample = 0
 baseline_method = "average"
-range = "2.0 (64.0)"
+range = [-2.0, 2.0]
 
 [daq.channels.ai3]
 enabled = true
@@ -64,7 +64,7 @@ baseline_start = 870
 baseline_stop = 899
 baseline_presample = 0
 baseline_method = "average"
-range = "0.5 (16.0)"
+range = [-0.5, 0.5]
 
 [daq.choppers.ai4]
 enabled = false

--- a/yaqd_ni/_ni_daqmx_tmux.py
+++ b/yaqd_ni/_ni_daqmx_tmux.py
@@ -7,7 +7,7 @@ import pathlib
 import ctypes
 
 from dataclasses import dataclass
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Tuple
 import warnings
 
 import numpy as np  # type: ignore

--- a/yaqd_ni/_ni_daqmx_tmux.py
+++ b/yaqd_ni/_ni_daqmx_tmux.py
@@ -101,9 +101,7 @@ class NiDaqmxTmux(HasMeasureTrigger, IsSensor, IsDaemon):
         self.ranges = self._get_voltage_ranges()
         is_similar_to_valid = lambda x: [all(np.isclose(x, r)) for r in self.ranges]
         invalid_ranges = [
-            ch.name 
-            for ch in self._channels 
-            if not any(is_similar_to_valid(ch.range))
+            ch.name for ch in self._channels if not any(is_similar_to_valid(ch.range))
         ]
         if invalid_ranges:
             self.logger.error(

--- a/yaqd_ni/_ni_daqmx_tmux.py
+++ b/yaqd_ni/_ni_daqmx_tmux.py
@@ -390,4 +390,4 @@ class NiDaqmxTmux(HasMeasureTrigger, IsSensor, IsDaemon):
 
     def get_allowed_voltage_ranges(self) -> List[str]:
         # stringify items to prevent floating point miscommunications
-        return [map(str, self.ranges)]
+        return list(map(str, self.ranges))

--- a/yaqd_ni/_ni_daqmx_tmux.py
+++ b/yaqd_ni/_ni_daqmx_tmux.py
@@ -114,6 +114,7 @@ class NiDaqmxTmux(HasMeasureTrigger, IsSensor, IsDaemon):
 
     def _get_voltage_ranges(self):
         import PyDAQmx  # type: ignore
+
         data = (ctypes.c_double * 40)()
         PyDAQmx.GetDevAIVoltageRngs(self._config["device_name"], data, len(data))
         # data = (-0.1, 0.1, -0.2, 0.2, ..., -10.0, 10.0, 0.0, 0.0, ...)

--- a/yaqd_ni/_ni_daqmx_tmux.py
+++ b/yaqd_ni/_ni_daqmx_tmux.py
@@ -7,7 +7,7 @@ import pathlib
 import ctypes
 
 from dataclasses import dataclass
-from typing import Dict, Any, List, Tuple
+from typing import Dict, Any, List
 import warnings
 
 import numpy as np  # type: ignore
@@ -103,7 +103,7 @@ class NiDaqmxTmux(HasMeasureTrigger, IsSensor, IsDaemon):
             lambda x: x in self.ranges
         )  # [all(np.isclose(x, r)) for r in self.ranges]
         invalid_ranges = [
-            ch.name for ch in self._channels if not any(is_similar_to_valid(ch.range))
+            ch.name for ch in self._channels if not is_similar_to_valid(ch.range)
         ]
         if invalid_ranges:
             self.logger.error(
@@ -124,7 +124,7 @@ class NiDaqmxTmux(HasMeasureTrigger, IsSensor, IsDaemon):
         PyDAQmx.GetDevAIVoltageRngs(self._config["device_name"], data, len(data))
         # data = (-0.1, 0.1, -0.2, 0.2, ..., -10.0, 10.0, 0.0, 0.0, ...)
         ranges = [
-            (round(data[i], 5), round(data[i + 1], 5))
+            (data[i], data[i + 1])
             for i in range(0, len(data), 2)
             if (data[i], data[i + 1]) != (0.0, 0.0)
         ]
@@ -390,5 +390,6 @@ class NiDaqmxTmux(HasMeasureTrigger, IsSensor, IsDaemon):
         """Set number of shots."""
         self._state["ms_wait"] = ms_wait
 
-    def get_allowed_voltage_ranges(self) -> List[Tuple[float, float]]:
-        return self.ranges
+    def get_allowed_voltage_ranges(self) -> List[str]:
+        # stringify items to prevent floating point miscommunications
+        return [map(str, self.ranges)]

--- a/yaqd_ni/_ni_daqmx_tmux.py
+++ b/yaqd_ni/_ni_daqmx_tmux.py
@@ -105,15 +105,19 @@ class NiDaqmxTmux(HasMeasureTrigger, IsSensor, IsDaemon):
             raise ValueError()
 
         # finish
-        self._stale_task = True        
+        self._stale_task = True
         self._create_sample_correspondances()
         self._create_task()
 
     def _get_voltage_ranges(self):
-        data = (ctypes.c_double * 40) ()
+        data = (ctypes.c_double * 40)()
         PyDAQmx.GetDevAIVoltageRngs(self.config["device_name"], data, len(data))
         # data = (-0.1, 0.1, -0.2, 0.2, ..., -10.0, 10.0, 0.0, 0.0, ...)
-        ranges = [(data[i], data[i+1]) for i in range(0, len(data), 2) if (data[i], data[i+1]) != (0., 0.)]
+        ranges = [
+            (data[i], data[i + 1])
+            for i in range(0, len(data), 2)
+            if (data[i], data[i + 1]) != (0.0, 0.0)
+        ]
         # remove extra buffer values
         if len(ranges) == len(data) // 2:
             self.logger.warn("Potentially did not discover all valid voltage ranges")

--- a/yaqd_ni/_ni_daqmx_tmux.py
+++ b/yaqd_ni/_ni_daqmx_tmux.py
@@ -99,7 +99,9 @@ class NiDaqmxTmux(HasMeasureTrigger, IsSensor, IsDaemon):
 
         # check channel ranges are valid
         self.ranges = self._get_voltage_ranges()
-        is_similar_to_valid = lambda x: x in self.ranges # [all(np.isclose(x, r)) for r in self.ranges]
+        is_similar_to_valid = (
+            lambda x: x in self.ranges
+        )  # [all(np.isclose(x, r)) for r in self.ranges]
         invalid_ranges = [
             ch.name for ch in self._channels if not any(is_similar_to_valid(ch.range))
         ]

--- a/yaqd_ni/_ni_daqmx_tmux.py
+++ b/yaqd_ni/_ni_daqmx_tmux.py
@@ -99,7 +99,7 @@ class NiDaqmxTmux(HasMeasureTrigger, IsSensor, IsDaemon):
 
         # check channel ranges are valid
         self.ranges = self._get_voltage_ranges()
-        is_similar_to_valid = lambda x: [all(np.isclose(x, r)) for r in self.ranges]
+        is_similar_to_valid = lambda x: x in self.ranges # [all(np.isclose(x, r)) for r in self.ranges]
         invalid_ranges = [
             ch.name for ch in self._channels if not any(is_similar_to_valid(ch.range))
         ]
@@ -122,7 +122,7 @@ class NiDaqmxTmux(HasMeasureTrigger, IsSensor, IsDaemon):
         PyDAQmx.GetDevAIVoltageRngs(self._config["device_name"], data, len(data))
         # data = (-0.1, 0.1, -0.2, 0.2, ..., -10.0, 10.0, 0.0, 0.0, ...)
         ranges = [
-            (data[i], data[i + 1])
+            (round(data[i], 5), round(data[i + 1], 5))
             for i in range(0, len(data), 2)
             if (data[i], data[i + 1]) != (0.0, 0.0)
         ]

--- a/yaqd_ni/_ni_daqmx_tmux.py
+++ b/yaqd_ni/_ni_daqmx_tmux.py
@@ -102,9 +102,7 @@ class NiDaqmxTmux(HasMeasureTrigger, IsSensor, IsDaemon):
         is_similar_to_valid = (
             lambda x: x in self.ranges
         )  # [all(np.isclose(x, r)) for r in self.ranges]
-        invalid_ranges = [
-            ch.name for ch in self._channels if not is_similar_to_valid(ch.range)
-        ]
+        invalid_ranges = [ch.name for ch in self._channels if not is_similar_to_valid(ch.range)]
         if invalid_ranges:
             self.logger.error(
                 f"""channels {invalid_ranges} have invalid voltage ranges. \

--- a/yaqd_ni/_ni_daqmx_tmux.py
+++ b/yaqd_ni/_ni_daqmx_tmux.py
@@ -31,7 +31,7 @@ def process_samples(method, samples):
 @dataclass
 class Channel:
     name: str
-    range: str
+    range: float
     enabled: bool
     physical_channel: str
     invert: bool
@@ -180,8 +180,7 @@ class NiDaqmxTmux(HasMeasureTrigger, IsSensor, IsDaemon):
                     physical_channel = (
                         "/" + self._config["device_name"] + "/" + channel.physical_channel
                     )
-                    min_voltage, max_voltage = -10, 10  # TODO
-                    # min_voltage, max_voltage = channel.get_range()
+                    min_voltage, max_voltage = [-channel.range, channel.range]
                 elif correspondance < 0:
                     chopper = self._choppers[-correspondance - 1]
                     physical_channel = (
@@ -242,7 +241,7 @@ class NiDaqmxTmux(HasMeasureTrigger, IsSensor, IsDaemon):
 
     async def _measure(self):
         await asyncio.sleep(self._state["ms_wait"] / 1000.0)
-        # this method runs syncronusly
+        # this method runs syncronously
         while True:
             samples = await self._loop.run_in_executor(None, self._measure_samples)
             if not self._stale_task:

--- a/yaqd_ni/_ni_daqmx_tmux.py
+++ b/yaqd_ni/_ni_daqmx_tmux.py
@@ -112,7 +112,7 @@ class NiDaqmxTmux(HasMeasureTrigger, IsSensor, IsDaemon):
         self._create_sample_correspondances()
         self._create_task()
 
-    def _get_voltage_ranges(self) -> List[tuple]:
+    def _get_voltage_ranges(self) -> List[Tuple[float, float]]:
         import PyDAQmx  # type: ignore
 
         data = (ctypes.c_double * 40)()
@@ -385,5 +385,5 @@ class NiDaqmxTmux(HasMeasureTrigger, IsSensor, IsDaemon):
         """Set number of shots."""
         self._state["ms_wait"] = ms_wait
 
-    def get_allowed_voltage_ranges(self) -> List[tuple]:
+    def get_allowed_voltage_ranges(self) -> List[Tuple[float, float]]:
         return self.ranges

--- a/yaqd_ni/_ni_daqmx_tmux.py
+++ b/yaqd_ni/_ni_daqmx_tmux.py
@@ -99,7 +99,12 @@ class NiDaqmxTmux(HasMeasureTrigger, IsSensor, IsDaemon):
 
         # check channel ranges are valid
         self.ranges = self._get_voltage_ranges()
-        invalid_ranges = [ch.name for ch in self._channels if ch.range not in self.ranges]
+        is_similar_to_valid = lambda x: [all(np.isclose(x, r)) for r in self.ranges]
+        invalid_ranges = [
+            ch.name 
+            for ch in self._channels 
+            if not any(is_similar_to_valid(ch.range))
+        ]
         if invalid_ranges:
             self.logger.error(
                 f"""channels {invalid_ranges} have invalid voltage ranges. \

--- a/yaqd_ni/_ni_daqmx_tmux.py
+++ b/yaqd_ni/_ni_daqmx_tmux.py
@@ -98,12 +98,12 @@ class NiDaqmxTmux(HasMeasureTrigger, IsSensor, IsDaemon):
         self._channel_units = {k: "V" for k in self._channel_names}  # expected by parent
 
         # check channel ranges are valid
-        ranges = self._get_voltage_ranges()
-        invalid_ranges = [ch.name for ch in self._channels if ch.range not in ranges]
+        self.ranges = self._get_voltage_ranges()
+        invalid_ranges = [ch.name for ch in self._channels if ch.range not in self.ranges]
         if invalid_ranges:
             self.logger.error(
                 f"""channels {invalid_ranges} have invalid voltage ranges. \
-                Valid ranges are {ranges}. """
+                Valid ranges are {self.ranges}. """
             )
             raise ValueError()
 
@@ -112,7 +112,7 @@ class NiDaqmxTmux(HasMeasureTrigger, IsSensor, IsDaemon):
         self._create_sample_correspondances()
         self._create_task()
 
-    def _get_voltage_ranges(self):
+    def _get_voltage_ranges(self) -> List[tuple]:
         import PyDAQmx  # type: ignore
 
         data = (ctypes.c_double * 40)()
@@ -384,3 +384,6 @@ class NiDaqmxTmux(HasMeasureTrigger, IsSensor, IsDaemon):
     def set_ms_wait(self, ms_wait):
         """Set number of shots."""
         self._state["ms_wait"] = ms_wait
+
+    def get_allowed_voltage_ranges(self) -> List[tuple]:
+        return self.ranges

--- a/yaqd_ni/_ni_daqmx_tmux.py
+++ b/yaqd_ni/_ni_daqmx_tmux.py
@@ -271,7 +271,7 @@ class NiDaqmxTmux(HasMeasureTrigger, IsSensor, IsDaemon):
 
     async def _measure(self):
         await asyncio.sleep(self._state["ms_wait"] / 1000.0)
-        # this method runs syncronously
+        # this method runs synchronously
         while True:
             samples = await self._loop.run_in_executor(None, self._measure_samples)
             if not self._stale_task:

--- a/yaqd_ni/ni-daqmx-tmux.avpr
+++ b/yaqd_ni/ni-daqmx-tmux.avpr
@@ -348,8 +348,10 @@
                     "type": "string"
                 },
                 {
+                    "default": 10.0,
+                    "doc": "The maximum value, in volts. Minimum value is the negative of max. Note that range will be coerced by device.",
                     "name": "range",
-                    "type": "string"
+                    "type": "float"
                 },
                 {
                     "default": true,

--- a/yaqd_ni/ni-daqmx-tmux.avpr
+++ b/yaqd_ni/ni-daqmx-tmux.avpr
@@ -225,6 +225,13 @@
             "request": [],
             "response": "string"
         },
+        "get_voltage_ranges": {
+            "request": [],
+            "response": {
+                "items": "voltage_range",
+                "type": "array"
+            }
+        },
         "id": {
             "doc": "JSON object with information to identify the daemon, including name, kind, make, model, serial.\n",
             "origin": "is-daemon",

--- a/yaqd_ni/ni-daqmx-tmux.avpr
+++ b/yaqd_ni/ni-daqmx-tmux.avpr
@@ -132,7 +132,7 @@
         "get_allowed_voltage_ranges": {
             "request": [],
             "response": {
-                "items": "voltage_range",
+                "items": "string",
                 "type": "array"
             }
         },

--- a/yaqd_ni/ni-daqmx-tmux.avpr
+++ b/yaqd_ni/ni-daqmx-tmux.avpr
@@ -342,16 +342,24 @@
             "type": "enum"
         },
         {
+            "items": "float",
+            "name": "voltage_range",
+            "type": "array"
+        },
+        {
             "fields": [
                 {
                     "name": "name",
                     "type": "string"
                 },
                 {
-                    "default": 10.0,
-                    "doc": "The maximum value, in volts. Minimum value is the negative of max. Note that range will be coerced by device.",
+                    "default": [
+                        -10.0,
+                        10.0
+                    ],
+                    "doc": "[min_value, max_value], in volts. Range values are restricted to those the available to the device.",
                     "name": "range",
-                    "type": "float"
+                    "type": "voltage_range"
                 },
                 {
                     "default": true,

--- a/yaqd_ni/ni-daqmx-tmux.toml
+++ b/yaqd_ni/ni-daqmx-tmux.toml
@@ -105,6 +105,9 @@ default = 0
 
 [messages]
 
+[messages.get_voltage_ranges]
+response = {"type"="array", "items"="voltage_range"}
+
 [messages.get_measured_samples]
 response = "ndarray"
 doc = "Get an array of shape (sample, shot)."

--- a/yaqd_ni/ni-daqmx-tmux.toml
+++ b/yaqd_ni/ni-daqmx-tmux.toml
@@ -21,19 +21,26 @@ default = "average"
 [[types]]
 type = "record"
 name = "channel"
-fields = [{"name"="name", "type"="string"},
-          {"name"="range", "type"="string"},
-          {"name"="enabled", "type"="boolean", "default"=true},
-	  {"name"="invert", "type"="boolean", "default"=false},
-	  {"name"="signal_start", "type"="int"},
-	  {"name"="signal_stop", "type"="int"},
-	  {"name"="signal_presample", "type"="int", default=0},
-	  {"name"="signal_method", "type"="processing_method"},
-	  {"name"="use_baseline", "type"="boolean", "default"=false},
-	  {"name"="baseline_start", "type"=["null", "int"], "default"="__null__"},
-	  {"name"="baseline_stop", "type"=["null", "int"], "default"="__null__"},
-	  {"name"="baseline_presample", "type"="int", default=0},
-	  {"name"="baseline_method", "type"="processing_method"}]
+fields = [
+	{"name"="name", "type"="string"},
+	{
+		"name"="range", 
+		"type"="float", 
+		"doc"="The maximum value, in volts. Minimum value is the negative of max. Note that range will be coerced by device.",
+		"default"=10.0
+	},
+	{"name"="enabled", "type"="boolean", "default"=true},
+	{"name"="invert", "type"="boolean", "default"=false},
+	{"name"="signal_start", "type"="int"},
+	{"name"="signal_stop", "type"="int"},
+	{"name"="signal_presample", "type"="int", default=0},
+	{"name"="signal_method", "type"="processing_method"},
+	{"name"="use_baseline", "type"="boolean", "default"=false},
+	{"name"="baseline_start", "type"=["null", "int"], "default"="__null__"},
+	{"name"="baseline_stop", "type"=["null", "int"], "default"="__null__"},
+	{"name"="baseline_presample", "type"="int", default=0},
+	{"name"="baseline_method", "type"="processing_method"}
+]
 
 [[types]]
 type = "record"

--- a/yaqd_ni/ni-daqmx-tmux.toml
+++ b/yaqd_ni/ni-daqmx-tmux.toml
@@ -106,7 +106,7 @@ default = 0
 [messages]
 
 [messages.get_allowed_voltage_ranges]
-response = {"type"="array", "items"="voltage_range"}
+response = {"type"="array", "items"="string"}
 
 [messages.get_measured_samples]
 response = "ndarray"

--- a/yaqd_ni/ni-daqmx-tmux.toml
+++ b/yaqd_ni/ni-daqmx-tmux.toml
@@ -24,8 +24,8 @@ name = "channel"
 fields = [
 	{"name"="name", "type"="string"},
 	{
-		"name"="range", 
-		"type"="float", 
+		"name"="range",
+		"type"="float",
 		"doc"="The maximum value, in volts. Minimum value is the negative of max. Note that range will be coerced by device.",
 		"default"=10.0
 	},

--- a/yaqd_ni/ni-daqmx-tmux.toml
+++ b/yaqd_ni/ni-daqmx-tmux.toml
@@ -25,8 +25,10 @@ fields = [
 	{"name"="name", "type"="string"},
 	{
 		"name"="range",
-		"type"="float",
-		"doc"="The maximum value, in volts. Minimum value is the negative of max. Note that range will be coerced by device.",
+		"type"="array",
+		"items"="float",
+		"doc"="""[min_value, max_value], in volts. \
+		Range values are restricted to those the available to the device.""",
 		"default"=10.0
 	},
 	{"name"="enabled", "type"="boolean", "default"=true},
@@ -143,3 +145,7 @@ setter = "set_ms_wait"
 type = "int"
 control_kind = "normal"
 record_kind = "metadata"
+
+[properties.channel_ranges]
+getter = "get_voltage_ranges"
+type = "list"

--- a/yaqd_ni/ni-daqmx-tmux.toml
+++ b/yaqd_ni/ni-daqmx-tmux.toml
@@ -19,17 +19,19 @@ symbols = ["average", "sum", "min", "max"]
 default = "average"
 
 [[types]]
+name = "voltage_range"
+type = "array"
+items = "float"
+
+[[types]]
 type = "record"
 name = "channel"
-fields = [
-	{"name"="name", "type"="string"},
+fields = [{"name"="name", "type"="string"},
 	{
 		"name"="range",
-		"type"="array",
-		"items"="float",
-		"doc"="""[min_value, max_value], in volts. \
-		Range values are restricted to those the available to the device.""",
-		"default"=10.0
+		"type" = "voltage_range",
+		"doc"="[min_value, max_value], in volts. Range values are restricted to those the available to the device.",
+		"default" = [-10.0, 10.0]
 	},
 	{"name"="enabled", "type"="boolean", "default"=true},
 	{"name"="invert", "type"="boolean", "default"=false},
@@ -146,6 +148,3 @@ type = "int"
 control_kind = "normal"
 record_kind = "metadata"
 
-[properties.channel_ranges]
-getter = "get_voltage_ranges"
-type = "list"

--- a/yaqd_ni/ni-daqmx-tmux.toml
+++ b/yaqd_ni/ni-daqmx-tmux.toml
@@ -105,7 +105,7 @@ default = 0
 
 [messages]
 
-[messages.get_voltage_ranges]
+[messages.get_allowed_voltage_ranges]
 response = {"type"="array", "items"="voltage_range"}
 
 [messages.get_measured_samples]


### PR DESCRIPTION
* in config, a channel's range is now a float argument (rather than a string that lists both range and resolution).  The daq will map signals to the interval [-range, +range].
* [The underlying device may coerce the configured range](https://www.ni.com/docs/en-US/bundle/ni-daqmx/page/mxcncpts/inputlimitcoercion.html).  To avoid user confusion, we enforce that the user input voltage ranges explicitly allowed by the device.  If the user supplies an invalid voltage range the error log will inform the user of allowed ranges.
* Allowed ranges are also accessible via the `get_allowed_voltage_ranges` message.  The message returns stringified ranges to avoid rounding point errors through the TCP layer.
* resolves #2 

